### PR TITLE
[MM-34278] Auto associate/disassociate AWS accounts with TGW share.

### DIFF
--- a/cmd/genesis/server.go
+++ b/cmd/genesis/server.go
@@ -49,6 +49,8 @@ func init() {
 	serverCmd.PersistentFlags().String("managed-ou", "", "The managed organizational unit")
 	serverCmd.PersistentFlags().String("control-tower-role", "", "The IAM role that will be assumed in the Control Tower account")
 	serverCmd.PersistentFlags().String("control-tower-account", "", "The AWS account ID of the Control Tower account")
+	serverCmd.PersistentFlags().String("resource-share-id", "", "The resource share to use when associating tgws with principals")
+	serverCmd.PersistentFlags().String("core-account", "", "The AWS account ID of the Cloud core account")
 
 	serverCmd.MarkFlagRequired("sso-user-email")
 	serverCmd.MarkFlagRequired("sso-first-name")
@@ -56,6 +58,8 @@ func init() {
 	serverCmd.MarkFlagRequired("managed-ou")
 	serverCmd.MarkFlagRequired("control-tower-role")
 	serverCmd.MarkFlagRequired("control-tower-account")
+	serverCmd.MarkFlagRequired("resource-share-id")
+	serverCmd.MarkFlagRequired("core-account")
 
 	// Supervisors
 	serverCmd.PersistentFlags().Int("poll", 30, "The interval in seconds to poll for background work.")
@@ -134,6 +138,9 @@ var serverCmd = &cobra.Command{
 		managedOU, _ := command.Flags().GetString("managed-ou")
 		controlTowerRole, _ := command.Flags().GetString("control-tower-role")
 		controlTowerAccountID, _ := command.Flags().GetString("control-tower-account")
+		resourceShareID, _ := command.Flags().GetString("resource-share-id")
+		coreAccountID, _ := command.Flags().GetString("core-account")
+
 		// Setup the provisioner for actually effecting changes to enterprise resources.
 		genesisProvisioner := genesis.NewGenesisProvisioner(
 			ssoUserEmail,
@@ -142,6 +149,8 @@ var serverCmd = &cobra.Command{
 			managedOU,
 			controlTowerRole,
 			controlTowerAccountID,
+			resourceShareID,
+			coreAccountID,
 			logger,
 		)
 

--- a/internal/aws/client.go
+++ b/internal/aws/client.go
@@ -22,6 +22,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/aws/aws-sdk-go/service/ram/ramiface"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
@@ -45,6 +47,8 @@ type AWS interface {
 	GetCloudEnvironmentName() (string, error)
 	AssumeRole(roleArn string) (*credentials.Credentials, error)
 	GetAccountID() (string, error)
+	AssociateTGWShare(resourceShareARN, principalID string) error
+	DisassociateTGWShare(resourceShareARN, principalID string) error
 }
 
 // NewAWSClientWithConfig returns a new instance of Client with a custom configuration.
@@ -73,6 +77,7 @@ type Service struct {
 	sts                   stsiface.STSAPI
 	appAutoscaling        applicationautoscalingiface.ApplicationAutoScalingAPI
 	serviceCatalog        servicecatalogiface.ServiceCatalogAPI
+	ram                   ramiface.RAMAPI
 }
 
 // NewService creates a new instance of Service.
@@ -91,6 +96,7 @@ func NewService(sess *session.Session) *Service {
 		sts:                   sts.New(sess),
 		appAutoscaling:        applicationautoscaling.New(sess),
 		serviceCatalog:        servicecatalog.New(sess),
+		ram:                   ram.New(sess),
 	}
 }
 

--- a/internal/aws/constants.go
+++ b/internal/aws/constants.go
@@ -21,4 +21,7 @@ const (
 	// DefaultAWSClientRetries supplies how many time the AWS client will
 	// retry a failed call.
 	DefaultAWSClientRetries = 3
+
+	// The name of the IAM role to use for TGW share associations.
+	TGWShareAssociationRole = "tgw-share-association-role"
 )

--- a/internal/aws/ram.go
+++ b/internal/aws/ram.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/pkg/errors"
+)
+
+func (a *Client) AssociateTGWShare(resourceShareARN, principalID string) error {
+	if _, err := a.Service().ram.AssociateResourceShare(&ram.AssociateResourceShareInput{
+		Principals:       []*string{aws.String(principalID)},
+		ResourceShareArn: aws.String(resourceShareARN),
+	}); err != nil {
+		return errors.Wrap(err, "failed to associate transit gateway with account")
+	}
+
+	return nil
+}
+
+func (a *Client) DisassociateTGWShare(resourceShareARN, principalID string) error {
+	if _, err := a.Service().ram.DisassociateResourceShare(&ram.DisassociateResourceShareInput{
+		Principals:       []*string{aws.String(principalID)},
+		ResourceShareArn: aws.String(resourceShareARN),
+	}); err != nil {
+		return errors.Wrap(err, "failed to disassociate transit gateway with account")
+	}
+
+	return nil
+}

--- a/internal/genesis/genesis_provisioner.go
+++ b/internal/genesis/genesis_provisioner.go
@@ -12,11 +12,13 @@ type GenProvisioner struct {
 	managedOU             string
 	controlTowerRole      string
 	controlTowerAccountID string
+	resourceShareID       string
+	coreAccountID         string
 	logger                log.FieldLogger
 }
 
 // NewGenesisProvisioner creates a new GenProvisioner.
-func NewGenesisProvisioner(ssoUserEmail, ssoFirstName, ssoLastName, managedOU, controlTowerRole, controlTowerAccountID string, logger log.FieldLogger) *GenProvisioner {
+func NewGenesisProvisioner(ssoUserEmail, ssoFirstName, ssoLastName, managedOU, controlTowerRole, controlTowerAccountID, resourceShareID, coreAccountID string, logger log.FieldLogger) *GenProvisioner {
 	logger = logger.WithField("provisioner", "genesis")
 
 	return &GenProvisioner{
@@ -26,6 +28,8 @@ func NewGenesisProvisioner(ssoUserEmail, ssoFirstName, ssoLastName, managedOU, c
 		managedOU:             managedOU,
 		controlTowerRole:      controlTowerRole,
 		controlTowerAccountID: controlTowerAccountID,
+		resourceShareID:       resourceShareID,
+		coreAccountID:         coreAccountID,
 		logger:                logger,
 	}
 }


### PR DESCRIPTION
#### Summary
With this PR:
- New accounts are automatically associated with the TGW share in core account 
- Deleted accounts are automatically disassociated with the TGW share in the core account 

This enables TGW attachments with no manual steps and ensures cleanup in account deletion.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34278
